### PR TITLE
ci: 🦺 (`.github`) E2Eテスト用のワークフローにビルドステップを追加した。 (#8)

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Playwrightをインストールする
         run: bun playwright install --with-deps
 
+      - name: Astroのビルド
+        run: bun run build
+
       - name: E2Eテストの実行
         run: bun test:e2e
 


### PR DESCRIPTION
- close #8