### PR TITLE
fix: 🐛 (`<ColoredContainer>`) 影が適用されない問題を修正した。  (#84)

### DIFF
--- a/src/components/ColoredContainer.astro
+++ b/src/components/ColoredContainer.astro
@@ -23,7 +23,7 @@ const { class: className, color = 'mauve', ...props } = Astro.props;
 
 <div
   class:list={[
-    "flex p-6 gap-6 rounded-3xl border shadow-bump bg-gradient-to-b from-mauve-1 ",
+    "flex p-6 gap-6 rounded-3xl border bg-gradient-to-b from-mauve-1 ",
     color === "mauve" &&
       "to-mauve-1 border-mauve-6 shadow-[0px_4px_16px_0px_var(--mauve-a3)]",
     color === "pink" &&


### PR DESCRIPTION
- close #84

- `shadow-bump`と`shadow-[0px_4px_0px_0px_var(--*-9),0px_4px_16px_0px_var(--*-a3)]`のCSS優先度に違いがないのにも関わらず、両方指定してしまったことが原因

<!-- 関連IssueをPRマージ時に自動クローズする記述を書く -->
<!-- - close [#3](https://github.com/shikosai33/shikosai33-web/issues/3) -->

## チケット URL

<!-- 該当するDiscordのフォーラムの投稿があれば記載 -->

## 概要

<!-- 変更内容の概要を記載 -->
<!-- 実装内容、背景、実装方法 -->

## レビューの丁寧さの希望

<!--必要なレビューの度合いにチェックマークを入れること -->

- [ ] Lv0: まったく見ないで Accept する
- [ ] Lv1: ぱっとみて違和感がないかチェックして Accept する
- [ ] Lv2: 仕様レベルまで理解して、コードレビューする
- [ ] LV3: 仕様レベルまで理解して、コードレビュー・動作確認する

## 確認用 URL

<!-- ローカルのURLや遷移方法などを記載 -->

## スクリーンショット

<!-- UIに変更差分があれば、スクショを添付 -->
<!-- 変更前、後両方添付するのが望ましい -->

## その他

<!-- 参考情報、共有したいことなどあれば、記載 -->

## チェックリスト

- [ ] ビルド、テストが異常終了しないことを確認した！
- [ ] 意図していないデバッグコードを全て取り除いた！
- [ ] PR にレビュー重要度(high, medium, low)のラベルをつけた！
