### PR TITLE
fix: 🐛 (`<Layout>`) View Transitionのページ遷移時にちらつきなく`.dark`が適用されるよう購読イベントを変更した。  (#123)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -182,7 +182,7 @@ const {
       document.addEventListener("shikosai33:updateTheme", () => {
         updateTheme(darkModeMediaQuery.matches);
       });
-      document.addEventListener("astro:page-load", () => {
+      document.addEventListener("astro:after-swap", () => {
         updateTheme(darkModeMediaQuery.matches);
       });
     </script>


### PR DESCRIPTION
- close #123

<!-- 関連IssueをPRマージ時に自動クローズする記述を書く -->
<!-- - close [#3](https://github.com/shikosai33/shikosai33-web/issues/3) -->

## チケット URL

<!-- 該当するDiscordのフォーラムの投稿があれば記載 -->

## 概要

- https://docs.astro.build/ja/guides/view-transitions/#astroafter-swap

<!-- 変更内容の概要を記載 -->
<!-- 実装内容、背景、実装方法 -->

## レビューの丁寧さの希望

<!--必要なレビューの度合いにチェックマークを入れること -->

- [ ] Lv0: まったく見ないで Accept する
- [ ] Lv1: ぱっとみて違和感がないかチェックして Accept する
- [ ] Lv2: 仕様レベルまで理解して、コードレビューする
- [x] LV3: 仕様レベルまで理解して、コードレビュー・動作確認する

## 確認用 URL

全てのページ
<!-- ローカルのURLや遷移方法などを記載 -->

## スクリーンショット

<!-- UIに変更差分があれば、スクショを添付 -->
<!-- 変更前、後両方添付するのが望ましい -->

## その他

<!-- 参考情報、共有したいことなどあれば、記載 -->

## チェックリスト

- [x] ビルド、テストが異常終了しないことを確認した！
- [x] 意図していないデバッグコードを全て取り除いた！
- [x] PR にレビュー重要度(high, medium, low)のラベルをつけた！
