### PR TITLE
`/root`のダウンロードボタンを実装した

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,11 +2,13 @@
 import '@/styles/global.css';
 import '@/styles/colors.css';
 import { ViewTransitions } from 'astro:transitions';
+import ButtonLink from '@/components/ButtonLink.astro';
 import HeroSlideShow from '@/components/HeroSlideShow.astro';
 import Footer from '@/components/footer.astro';
 import Header from '@/components/header.astro';
 import { GoogleFontsOptimizer } from 'astro-google-fonts-optimizer';
 import { SEO } from 'astro-seo';
+import { CloudDownload } from 'lucide-astro';
 
 /**
  *メタデータやOpengraph、Twitterカードの情報を設定するためのレイアウト。
@@ -144,7 +146,7 @@ const {
 
       // ダークモードかどうかを判定するメディアクエリ
       const darkModeMediaQuery = window.matchMedia(
-        "(prefers-color-scheme: dark)"
+        "(prefers-color-scheme: dark)",
       );
 
       /**
@@ -202,7 +204,22 @@ const {
         transition:persist
         class="w-full mb-8 group-data-[no-hero]:max-md:hidden"
       />
+      {
+        hasHero && (
+          <div class="grid justify-around grid-cols-2 gap-5">
+            <ButtonLink color="pink">
+              <CloudDownload />
+              <span class="text-base">パンフレット (11.5MB)</span>
+            </ButtonLink>
+            <ButtonLink color="mauve">
+              <CloudDownload />
+              <span class="text-base">ポスター (13.4MB)</span>
+            </ButtonLink>
+          </div>
+        )
+      }
     </div>
+
     <div
       class="relative px-1 md:px-0 z-10 flex flex-col gap-6 w-full md:w-[calc(100%-(100svh-64px-32px-24px*3)*0.7071-24px*3)] md:min-w-[calc(100%-40vw-24px*3)] grow justify-start min-h-[calc(100svh-24px*2)] mt-6 md:mt-0 md:ml-6"
     >

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -207,11 +207,21 @@ const {
       {
         hasHero && (
           <div class="grid justify-around grid-cols-2 gap-5">
-            <ButtonLink color="pink">
+            <ButtonLink
+              color="pink"
+              target="_black"
+              rel="noopener noreferrer"
+              href="https://bucket.33.shikosai.net/brochure.pdf"
+            >
               <CloudDownload />
               <span class="text-base">パンフレット (11.5MB)</span>
             </ButtonLink>
-            <ButtonLink color="mauve">
+            <ButtonLink
+              color="mauve"
+              target="_black"
+              rel="noopener noreferrer"
+              href="https://bucket.33.shikosai.net/poster.png"
+            >
               <CloudDownload />
               <span class="text-base">ポスター (13.4MB)</span>
             </ButtonLink>


### PR DESCRIPTION
のみ、かつデスクトップ版の場合は最下層までスクロールしないと表示されない
- close #126 
<!-- 関連IssueをPRマージ時に自動クローズする記述を書く -->
<!-- - close [#3](https://github.com/shikosai33/shikosai33-web/issues/3) -->

## チケット URL

<!-- 該当するDiscordのフォーラムの投稿があれば記載 -->

## 概要
`/root`の`HeroSlideshow`の下にポスターとパンフレットのダウンロードを実装した
<!-- 変更内容の概要を記載 -->
<!-- 実装内容、背景、実装方法 -->

## レビューの丁寧さの希望

<!--必要なレビューの度合いにチェックマークを入れること -->

- [ ] Lv0: まったく見ないで Accept する
- [ ] Lv1: ぱっとみて違和感がないかチェックして Accept する
- [x] Lv2: 仕様レベルまで理解して、コードレビューする
- [ ] LV3: 仕様レベルまで理解して、コードレビュー・動作確認する

## 確認用 URL

<!-- ローカルのURLや遷移方法などを記載 -->

## スクリーンショット
![image](https://github.com/user-attachments/assets/6daa2051-508c-4136-9cc1-1437e1cc4454)
<!-- UIに変更差分があれば、スクショを添付 -->
<!-- 変更前、後両方添付するのが望ましい -->

## その他
`/root`でのみの実装
<!-- 参考情報、共有したいことなどあれば、記載 -->

## チェックリスト

- [x] ビルド、テストが異常終了しないことを確認した！
- [x] 意図していないデバッグコードを全て取り除いた！
- [x] PR にレビュー重要度(high, medium, low)のラベルをつけた！
